### PR TITLE
Fix Ahrefs SEO regression from broken react-snap prerender

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build && cp build/index.html build/404.html",
-    "postbuild": "react-snap",
+    "postbuild": "react-snap; node scripts/injectPrerenderMeta.js",
     "test": "react-scripts test",
     "test:e2e:install": "playwright install chromium",
     "test:e2e": "playwright test",
@@ -63,6 +63,7 @@
   },
   "reactSnap": {
     "include": [
+      "/",
       "/o25",
       "/u25",
       "/bttsteams",
@@ -70,16 +71,14 @@
       "/bttsfixtures",
       "/fixtureshigh",
       "/teamshigh",
-      "/reset",
-      "/cancelsubscription",
       "/worldcup2026"
     ],
     "crawl": false,
     "puppeteerArgs": [
       "--no-sandbox"
     ],
-    "timeout": 30000,
-    "waitFor": 3000,
+    "timeout": 60000,
+    "waitFor": 5000,
     "removeStyleTags": false,
     "inlineCss": true
   },

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,6 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>SoccerStatsHub</title>
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />

--- a/scripts/injectPrerenderMeta.js
+++ b/scripts/injectPrerenderMeta.js
@@ -1,0 +1,157 @@
+/**
+ * Ensures each prerendered route has exactly one set of SEO tags in static HTML.
+ * react-snap + react-helmet can leave stale or partial head tags after index.html changes.
+ */
+const fs = require("fs");
+const path = require("path");
+
+const BUILD_DIR = path.join(__dirname, "..", "build");
+const SITE_URL = "https://www.soccerstatshub.com";
+const OG_IMAGE = `${SITE_URL}/images/social-share-card.jpg`;
+const SITE_NAME = "SoccerStatsHub";
+
+const PAGE_META = {
+  "/": {
+    title: "SoccerStatsHub | Football Stats, Predictions & Tips",
+    description:
+      "Data-driven football stats, BTTS tips, Over 2.5 predictions, correct score analysis and daily multis for today's matches.",
+  },
+  "/o25/": {
+    title: "Over 2.5 Goals Teams | SoccerStatsHub",
+    description:
+      "Elite scoring teams with the highest average goals and upcoming fixtures. Find the best Over 2.5 goals betting opportunities.",
+  },
+  "/u25/": {
+    title: "Under 2.5 Goals Leagues | SoccerStatsHub",
+    description:
+      "Leagues with the lowest goals-per-match averages. Identify Under 2.5 goals value across top European and international competitions.",
+  },
+  "/teamshigh/": {
+    title: "Highest Scoring Teams | SoccerStatsHub",
+    description:
+      "Teams ranked by goals scored this season. Compare attacking form and find high-scoring sides across major leagues.",
+  },
+  "/fixtureshigh/": {
+    title: "Highest Scoring Fixtures | SoccerStatsHub",
+    description:
+      "Today's fixtures with the highest goal potential. Data-driven insights to find matches likely to produce goals.",
+  },
+  "/bttsfixtures/": {
+    title: "BTTS Fixtures Today | SoccerStatsHub",
+    description:
+      "Both Teams To Score fixture insights for today's matches. Stats-backed BTTS picks across major leagues.",
+  },
+  "/bttsteams/": {
+    title: "BTTS Teams | SoccerStatsHub",
+    description:
+      "Teams with the strongest Both Teams To Score records. Find BTTS-elite sides and their upcoming fixtures.",
+  },
+  "/worldcup2026/": {
+    title: "World Cup 2026 Preview | SoccerStatsHub",
+    description:
+      "FIFA World Cup 2026 tournament preview: predicted winner, Golden Boot picks, group predictions, all 48 team guides and key match predictions.",
+  },
+  "/seasonpreviews/": {
+    title: "Season Previews | SoccerStatsHub",
+    description:
+      "AI-powered season previews for the Premier League, La Liga, Serie A, Championship and more.",
+  },
+};
+
+const PRERENDER_ROUTES = Object.keys(PAGE_META);
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function getCanonicalUrl(pathname) {
+  if (pathname === "/") return `${SITE_URL}/`;
+  return `${SITE_URL}${pathname}`;
+}
+
+function buildSeoBlock(pathname) {
+  const meta = PAGE_META[pathname];
+  const canonicalUrl = getCanonicalUrl(pathname);
+  const title = escapeHtml(meta.title);
+  const description = escapeHtml(meta.description);
+
+  return [
+    `<title>${title}</title>`,
+    `<meta name="description" content="${description}">`,
+    `<link rel="canonical" href="${canonicalUrl}">`,
+    `<meta property="og:title" content="${title}">`,
+    `<meta property="og:description" content="${description}">`,
+    `<meta property="og:image" content="${OG_IMAGE}">`,
+    `<meta property="og:url" content="${canonicalUrl}">`,
+    `<meta property="og:type" content="website">`,
+    `<meta property="og:site_name" content="${SITE_NAME}">`,
+    `<meta property="og:locale" content="en_GB">`,
+    `<meta name="twitter:card" content="summary_large_image">`,
+    `<meta name="twitter:title" content="${title}">`,
+    `<meta name="twitter:description" content="${description}">`,
+    `<meta name="twitter:image" content="${OG_IMAGE}">`,
+  ].join("\n  ");
+}
+
+function stripSeoTags(html) {
+  return html
+    .replace(/<title[^>]*>[\s\S]*?<\/title>/gi, "")
+    .replace(/<meta[^>]+name=["']description["'][^>]*>/gi, "")
+    .replace(/<meta[^>]+name=["']robots["'][^>]*>/gi, "")
+    .replace(/<meta[^>]+property=["']og:[^"']+["'][^>]*>/gi, "")
+    .replace(/<meta[^>]+name=["']twitter:[^"']+["'][^>]*>/gi, "")
+    .replace(/<link[^>]+rel=["']canonical["'][^>]*>/gi, "");
+}
+
+function stripStalePrerenderMarkup(html) {
+  return html
+    .replace(/<div class="sr-only">[\s\S]*?<\/div>/gi, "")
+    .replace(/<h1>SoccerStatsHub(?:\s*–\s*Football Stats, Predictions &amp; Tips)?<\/h1>/gi, "");
+}
+
+function injectSeoTags(html, pathname) {
+  const cleaned = stripStalePrerenderMarkup(stripSeoTags(html));
+  const seoBlock = buildSeoBlock(pathname);
+
+  return cleaned.replace(
+    /(<meta[^>]+name=["']viewport["'][^>]*>)/i,
+    `$1\n  ${seoBlock}`
+  );
+}
+
+function routeToFilePath(route) {
+  if (route === "/") return path.join(BUILD_DIR, "index.html");
+  const folder = route.replace(/\/$/, "");
+  return path.join(BUILD_DIR, folder, "index.html");
+}
+
+function ensureRouteHtml(route) {
+  const targetPath = routeToFilePath(route);
+  const sourcePath = path.join(BUILD_DIR, "index.html");
+
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`Missing build template at ${sourcePath}`);
+  }
+
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+
+  if (!fs.existsSync(targetPath)) {
+    fs.copyFileSync(sourcePath, targetPath);
+  }
+
+  const html = fs.readFileSync(targetPath, "utf8");
+  fs.writeFileSync(targetPath, injectSeoTags(html, route));
+}
+
+function main() {
+  PRERENDER_ROUTES.forEach((route) => {
+    ensureRouteHtml(route);
+    console.log(`Injected SEO tags for ${route}`);
+  });
+}
+
+main();

--- a/src/components/PageMeta.js
+++ b/src/components/PageMeta.js
@@ -16,7 +16,7 @@ const PageMeta = ({ title, description, noIndex }) => {
   const canonicalUrl = getCanonicalUrl(pathname);
 
   return (
-    <Helmet>
+    <Helmet prioritizeSeoTags>
       <title>{pageTitle}</title>
       <meta name="description" content={pageDescription} />
       <link rel="canonical" href={canonicalUrl} />

--- a/src/components/SiteHeader.js
+++ b/src/components/SiteHeader.js
@@ -3,6 +3,7 @@ import HamburgerMenu from "./HamburgerMenu";
 import ThemeToggle from "./DarkModeToggle";
 import WorldCupBanner from "./WorldCupBanner";
 import Footer from "./Footer";
+import { SITE_NAV_LINKS } from "../seo/siteNavLinks";
 
 export default function SiteHeader({
   showThemeToggle = false,
@@ -13,6 +14,13 @@ export default function SiteHeader({
     <>
       <header className="DarkMode">
         <Logo />
+        <nav className="DesktopNav" aria-label="Main navigation">
+          {SITE_NAV_LINKS.map((item) => (
+            <a key={item.path} href={item.path} className="DesktopNav-link">
+              {item.label}
+            </a>
+          ))}
+        </nav>
         <div className="HeaderActions">
           <HamburgerMenu />
           {showThemeToggle && <ThemeToggle />}

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -2,17 +2,20 @@ import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
+const isReactSnap =
+  typeof navigator !== "undefined" && navigator.userAgent === "ReactSnap";
+
 const firebaseConfig = {
-apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
-  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.REACT_APP_FIREBASE_APP_ID,
-  measurementId:process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY || "react-snap-placeholder-key",
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN || "localhost",
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID || "react-snap",
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET || "react-snap.appspot.com",
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID || "0",
+  appId: process.env.REACT_APP_FIREBASE_APP_ID || "react-snap",
+  measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
 };
 
 const app = initializeApp(firebaseConfig);
 
-export const auth = getAuth(app);
-export const db = getFirestore(app);
+export const auth = isReactSnap ? null : getAuth(app);
+export const db = isReactSnap ? null : getFirestore(app);

--- a/src/index.css
+++ b/src/index.css
@@ -575,6 +575,34 @@ h1 {
   margin-right: 0;
 }
 
+.DesktopNav {
+  display: none;
+  flex: 1;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75em 1.25em;
+  padding: 0 1em;
+}
+
+.DesktopNav-link {
+  color: var(--text-color);
+  font-size: 0.9em;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.DesktopNav-link:hover {
+  color: var(--accent-color);
+  text-decoration: underline;
+}
+
+@media (min-width: 1024px) {
+  .DesktopNav {
+    display: flex;
+  }
+}
+
 .HamburgerMenuDiv {
   margin: 0;
   padding: 0;

--- a/src/logic/authProvider.js
+++ b/src/logic/authProvider.js
@@ -17,11 +17,16 @@ export const AuthProvider = ({ children }) => {
   const [fixtures, setFixtures] = useState([]);
 const [isPredicting, setIsPredicting] = useState(false);
   useEffect(() => {
+    if (!auth) {
+      setLoading(false);
+      return undefined;
+    }
+
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
       setUser(currentUser);
       userDetail = currentUser;
-      
-      if (currentUser) {
+
+      if (currentUser && db) {
         // Check Firestore for subscription status using currentUser.email or uid
         // (Adjust the document reference as needed)
         const userRef = doc(db, "users", currentUser.uid);

--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -1,17 +1,27 @@
-// utils/render.js
-import { createRoot } from 'react-dom/client';
+import { createRoot, hydrateRoot } from "react-dom/client";
 
 const roots = new Map();
+
+function hasPrerenderedAppContent(container) {
+  return Boolean(
+    container.querySelector(".App, .SubpageContent, .WC26, .p-4")
+  );
+}
 
 export function render(element, containerId) {
   const container = document.getElementById(containerId);
   if (!container) return;
 
-  // Reuse existing root if it exists
   let root = roots.get(containerId);
   if (!root) {
-    root = createRoot(container);
+    if (hasPrerenderedAppContent(container)) {
+      root = hydrateRoot(container, element);
+    } else {
+      root = createRoot(container);
+      root.render(element);
+    }
     roots.set(containerId, root);
+    return;
   }
 
   root.render(element);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The previous Ahrefs SEO commit removed static meta tags from `index.html` so `PageMeta` could be the single source of truth. That is correct for client-side rendering, but this site relies on **react-snap** prerendering for crawlers. After deploy, stale/partial prerender snapshots caused the Ahrefs score to drop.

## Root cause

Live `/o25/` HTML showed the correct page title but **homepage** canonical, description, and Open Graph values. Ahrefs also still saw legacy sr-only `<h1>` markup baked into old snapshots, producing:

- Multiple meta description tags (static + react-helmet)
- Open Graph URL not matching canonical / page URL
- Multiple H1 tags
- Page and SERP title mismatches
- Weak internal linking (desktop nav removed; hamburger links hidden until opened)

## Fix

1. **Postbuild meta injection** (`scripts/injectPrerenderMeta.js`) — writes exactly one SEO tag set per indexable route into prerendered HTML, and strips stale sr-only markup.
2. **react-snap reliability** — Firebase/auth guards during prerender; homepage added to snap include; noindex routes removed from snap include.
3. **Hydration fix** — only hydrate when real app markup exists (not the splash loader), avoiding React hydration errors during snap.
4. **Internal linking** — restore visible desktop navigation in `SiteHeader` using `SITE_NAV_LINKS`.
5. **Helmet** — enable `prioritizeSeoTags` on `PageMeta`.

## Verification

Local build output for `/o25/` now contains a single description/canonical/og:url block pointing at `https://www.soccerstatshub.com/o25/`.

After merge, deploy with `npm run deploy` and re-run the Ahrefs site audit to confirm the health score recovers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d015b06-de72-48a0-bdc7-0c2d31f5efd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d015b06-de72-48a0-bdc7-0c2d31f5efd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

