### PR TITLE
Edge-cached API proxy for app-load data

### DIFF
--- a/pages/api/ss/[...path].js
+++ b/pages/api/ss/[...path].js
@@ -1,9 +1,12 @@
 // Edge-cached read-through proxy to the Express data origin.
 //
-// The client calls /api/ss/<origin-path> instead of hitting the origin
-// directly, so Vercel's CDN can serve repeat/global traffic without waking the
-// (slow) origin on every page load. Only GET requests to globally-cacheable
-// endpoints are allowed; anything user-specific must keep calling the origin.
+// Runs on the Edge runtime and streams the upstream body straight through, so
+// large payloads (e.g. /results) aren't buffered and aren't subject to the 4MB
+// Node serverless response limit. The client calls /api/ss/<origin-path>
+// instead of the origin directly, letting Vercel's CDN cache global traffic.
+// Only GET requests to allowlisted, non-personalised endpoints are proxied.
+
+export const config = { runtime: "edge" };
 
 const ORIGIN =
   process.env.EXPRESS_SERVER || process.env.NEXT_PUBLIC_EXPRESS_SERVER;
@@ -24,32 +27,37 @@ const CACHE_RULES = {
   "league-averages": { sMaxAge: 600, swr: 86400 },
 };
 
-export default async function handler(req, res) {
+function jsonError(body, status, extraHeaders) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      ...extraHeaders,
+    },
+  });
+}
+
+export default async function handler(req) {
   if (req.method !== "GET") {
-    res.setHeader("Allow", "GET");
-    return res.status(405).json({ error: "Method not allowed" });
+    return jsonError({ error: "Method not allowed" }, 405, { Allow: "GET" });
   }
-
   if (!ORIGIN) {
-    return res.status(500).json({ error: "Origin not configured" });
+    return jsonError({ error: "Origin not configured" }, 500);
   }
 
-  const segments = Array.isArray(req.query.path)
-    ? req.query.path
-    : [req.query.path];
+  const url = new URL(req.url);
+  const rest = url.pathname.replace(/^\/api\/ss\//, "").replace(/\/+$/, "");
+  const segments = rest.split("/");
   const head = segments[0];
   const rule = CACHE_RULES[head];
 
   // Only allowlisted, non-personalised endpoints may be proxied + cached.
   if (!rule) {
-    return res
-      .status(404)
-      .json({ error: `Endpoint '${head}' is not proxyable` });
+    return jsonError({ error: `Endpoint '${head}' is not proxyable` }, 404);
   }
 
-  // Preserve any original query string (e.g. ?page=2).
-  const qs = req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : "";
-  const target = `${ORIGIN}${segments.join("/")}${qs}`;
+  const target = `${ORIGIN}${segments.join("/")}${url.search}`;
 
   try {
     const upstream = await fetch(target, {
@@ -61,27 +69,29 @@ export default async function handler(req, res) {
       },
     });
 
-    const body = await upstream.text();
+    const contentType =
+      upstream.headers.get("content-type") || "application/json";
 
     if (!upstream.ok) {
       // Don't cache origin errors, so a transient blip isn't pinned for minutes.
-      res.setHeader("Cache-Control", "no-store");
-      return res.status(upstream.status).send(body);
+      return new Response(upstream.body, {
+        status: upstream.status,
+        headers: { "Cache-Control": "no-store", "Content-Type": contentType },
+      });
     }
 
-    res.setHeader(
-      "Cache-Control",
-      `public, s-maxage=${rule.sMaxAge}, stale-while-revalidate=${rule.swr}`
-    );
-    res.setHeader(
-      "Content-Type",
-      upstream.headers.get("content-type") || "application/json"
-    );
-    return res.status(200).send(body);
+    // Stream the body through with CDN cache headers; nothing is buffered.
+    return new Response(upstream.body, {
+      status: 200,
+      headers: {
+        "Cache-Control": `public, s-maxage=${rule.sMaxAge}, stale-while-revalidate=${rule.swr}`,
+        "Content-Type": contentType,
+      },
+    });
   } catch (err) {
-    res.setHeader("Cache-Control", "no-store");
-    return res
-      .status(502)
-      .json({ error: "Upstream fetch failed", detail: String(err) });
+    return jsonError(
+      { error: "Upstream fetch failed", detail: String(err) },
+      502
+    );
   }
 }

--- a/pages/api/ss/[...path].js
+++ b/pages/api/ss/[...path].js
@@ -1,0 +1,87 @@
+// Edge-cached read-through proxy to the Express data origin.
+//
+// The client calls /api/ss/<origin-path> instead of hitting the origin
+// directly, so Vercel's CDN can serve repeat/global traffic without waking the
+// (slow) origin on every page load. Only GET requests to globally-cacheable
+// endpoints are allowed; anything user-specific must keep calling the origin.
+
+const ORIGIN =
+  process.env.EXPRESS_SERVER || process.env.NEXT_PUBLIC_EXPRESS_SERVER;
+
+// Per-endpoint freshness, keyed by the first path segment.
+//   sMaxAge: how long the CDN serves a fresh copy before revalidating.
+//   swr: how long a stale copy may be served instantly while it refreshes.
+// Keep these keys in sync with PROXIED_ENDPOINTS in src/utils/apiUrl.js.
+const CACHE_RULES = {
+  matches: { sMaxAge: 120, swr: 86400 },
+  results: { sMaxAge: 300, swr: 86400 },
+  tables: { sMaxAge: 600, swr: 86400 },
+  leagues: { sMaxAge: 300, swr: 86400 },
+  form: { sMaxAge: 300, swr: 86400 },
+  formTeam: { sMaxAge: 300, swr: 86400 },
+  leagueFixtures: { sMaxAge: 300, swr: 86400 },
+  scheduledEvents: { sMaxAge: 300, swr: 86400 },
+  "league-averages": { sMaxAge: 600, swr: 86400 },
+};
+
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  if (!ORIGIN) {
+    return res.status(500).json({ error: "Origin not configured" });
+  }
+
+  const segments = Array.isArray(req.query.path)
+    ? req.query.path
+    : [req.query.path];
+  const head = segments[0];
+  const rule = CACHE_RULES[head];
+
+  // Only allowlisted, non-personalised endpoints may be proxied + cached.
+  if (!rule) {
+    return res
+      .status(404)
+      .json({ error: `Endpoint '${head}' is not proxyable` });
+  }
+
+  // Preserve any original query string (e.g. ?page=2).
+  const qs = req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : "";
+  const target = `${ORIGIN}${segments.join("/")}${qs}`;
+
+  try {
+    const upstream = await fetch(target, {
+      headers: {
+        ...(process.env.NEXT_PUBLIC_API_KEY
+          ? { "x-api-key": process.env.NEXT_PUBLIC_API_KEY }
+          : {}),
+        accept: "application/json",
+      },
+    });
+
+    const body = await upstream.text();
+
+    if (!upstream.ok) {
+      // Don't cache origin errors, so a transient blip isn't pinned for minutes.
+      res.setHeader("Cache-Control", "no-store");
+      return res.status(upstream.status).send(body);
+    }
+
+    res.setHeader(
+      "Cache-Control",
+      `public, s-maxage=${rule.sMaxAge}, stale-while-revalidate=${rule.swr}`
+    );
+    res.setHeader(
+      "Content-Type",
+      upstream.headers.get("content-type") || "application/json"
+    );
+    return res.status(200).send(body);
+  } catch (err) {
+    res.setHeader("Cache-Control", "no-store");
+    return res
+      .status(502)
+      .json({ error: "Upstream fetch failed", detail: String(err) });
+  }
+}

--- a/src/logic/getFixtures.js
+++ b/src/logic/getFixtures.js
@@ -17,6 +17,7 @@ import Collapsable from "../components/CollapsableElement";
 import { userDetail, triggerGlobalPredictions } from "./authProvider";
 import { leagueStatsArray, playerStatsArray } from "../logic/getScorePredictions";
 import { getLeagueFixturesByLeagueId } from "../utils/leagueResultsAccess";
+import { apiGetUrl } from "../utils/apiUrl";
 const LazyLeagueTable = lazy(() => import('../components/LeagueTable'));
 
 var oddslib = require("oddslib");
@@ -791,7 +792,7 @@ export async function generateFixtures(
     };
     // Reset before each date load so GameStats SofaScore lookups cannot match stale games.
     arrayOfGames = [];
-    await fetch(`${process.env.NEXT_PUBLIC_EXPRESS_SERVER}scheduledEvents/${dateSS}`)
+    await fetch(apiGetUrl(`scheduledEvents/${dateSS}`))
       .then(res => res.json())
       .then(games => {
         games.forEach((game) => {
@@ -871,16 +872,14 @@ export async function generateFixtures(
       [leaguesDate] = await calculateDate(new Date());
     }
 
-    const url = `${process.env.NEXT_PUBLIC_EXPRESS_SERVER}matches/${footyStatsFormattedDate}`;
-    const formUrl = `${process.env.NEXT_PUBLIC_EXPRESS_SERVER}form/${date}`;
+    const url = apiGetUrl(`matches/${footyStatsFormattedDate}`);
+    const formUrl = apiGetUrl(`form/${date}`);
     dynamicDate = unformattedDate;
 
     matches = [];
     fixtureArray = [];
 
-    league = await fetch(
-      `${process.env.NEXT_PUBLIC_EXPRESS_SERVER}leagues/${leaguesDate}`
-    );
+    league = await fetch(apiGetUrl(`leagues/${leaguesDate}`));
 
     // render(<div></div>, "FixtureContainer");
 
@@ -920,9 +919,7 @@ export async function generateFixtures(
 
     let allLeagueResults;
 
-    allLeagueResults = await fetch(
-      `${process.env.NEXT_PUBLIC_EXPRESS_SERVER}results`
-    );
+    allLeagueResults = await fetch(apiGetUrl(`results`));
 
     if (
       league.status === 200 &&
@@ -953,7 +950,7 @@ export async function generateFixtures(
       console.log("Fetching leagues");
       for (let i = 0; i < orderedLeagues.length; i++) {
         league = await fetch(
-          `${process.env.NEXT_PUBLIC_EXPRESS_SERVER}tables/${orderedLeagues[i].element.id}/${leaguesDate}`
+          apiGetUrl(`tables/${orderedLeagues[i].element.id}/${leaguesDate}`)
         );
         // eslint-disable-next-line no-loop-func
         await league.json().then((table) => {
@@ -970,7 +967,7 @@ export async function generateFixtures(
 
       for (const orderedLeague of orderedLeagues) {
         let fixtures = await fetch(
-          `${process.env.NEXT_PUBLIC_EXPRESS_SERVER}leagueFixtures/${orderedLeague.element.id}`
+          apiGetUrl(`leagueFixtures/${orderedLeague.element.id}`)
         );
 
         let games = await fixtures.json();
@@ -978,7 +975,7 @@ export async function generateFixtures(
         let gamesShortened;
         if (games.pager.current_page < games.pager.max_page) {
           const page2 = await fetch(
-            `${process.env.NEXT_PUBLIC_EXPRESS_SERVER}leagueFixtures/${orderedLeague.element.id}&page=2`
+            apiGetUrl(`leagueFixtures/${orderedLeague.element.id}&page=2`)
           );
           let page2Data = await page2.json();
 

--- a/src/logic/getForm.js
+++ b/src/logic/getForm.js
@@ -1,3 +1,5 @@
+import { apiGetUrl } from "../utils/apiUrl";
+
 export async function getForm(match) {
   const teams = [match.homeId, match.awayId];
   const fixtureForm = [];
@@ -5,9 +7,7 @@ export async function getForm(match) {
   for (let i = 0; i < teams.length; i++) {
     const team = teams[i];
 
-    let response = await fetch(
-      `${process.env.NEXT_PUBLIC_EXPRESS_SERVER}formTeam/${team}`
-    );
+    let response = await fetch(apiGetUrl(`formTeam/${team}`));
     await response.json().then((formData) => {
       formData.lastMatchTimestamp = formData.last_updated_match_timestamp
       fixtureForm[i] = formData;

--- a/src/logic/getScorePredictions.js
+++ b/src/logic/getScorePredictions.js
@@ -1,6 +1,7 @@
 import { Fragment, useState } from "react";
 import ReactDOM from "react-dom";
 import { isReactSnap } from "../firebase";
+import { apiGetUrl } from "../utils/apiUrl";
 import { matches, diff } from "./getFixtures";
 import { RenderAllFixtures } from "../logic/getFixtures";
 import Collapsable from "../components/CollapsableElement";
@@ -5982,7 +5983,7 @@ export async function getScorePrediction(day, mocked) {
 
 
   const predictedScoresPromise = fetch(`${process.env.NEXT_PUBLIC_EXPRESS_SERVER}predictedScores2`);
-  const leagueAveragesPromise = fetch(`${process.env.NEXT_PUBLIC_EXPRESS_SERVER}league-averages`);
+  const leagueAveragesPromise = fetch(apiGetUrl(`league-averages`));
 
   // 2. Await everything in parallel
   const [

--- a/src/utils/apiUrl.js
+++ b/src/utils/apiUrl.js
@@ -1,0 +1,30 @@
+// Endpoints whose GET responses are global (identical for every visitor) and so
+// can be served through the edge-cached proxy at /api/ss/*. Keep this in sync
+// with CACHE_RULES in pages/api/ss/[...path].js. User-specific endpoints
+// (e.g. predictedScores2, tipsNEW) are intentionally absent so they keep
+// hitting the origin directly and are never cached.
+const PROXIED_ENDPOINTS = new Set([
+  "matches",
+  "results",
+  "tables",
+  "leagues",
+  "form",
+  "formTeam",
+  "leagueFixtures",
+  "scheduledEvents",
+  "league-averages",
+]);
+
+const ORIGIN = process.env.NEXT_PUBLIC_EXPRESS_SERVER;
+
+// Build a URL for a read (GET) request to the data API. Allowlisted, globally
+// cacheable endpoints are routed through the same-origin Vercel proxy (so the
+// CDN can cache them); everything else — and any server-side call, where the
+// relative proxy path wouldn't resolve — falls back to the origin.
+export function apiGetUrl(path) {
+  const head = String(path).split(/[/?&]/)[0];
+  if (typeof window !== "undefined" && PROXIED_ENDPOINTS.has(head)) {
+    return `/api/ss/${path}`;
+  }
+  return `${ORIGIN}${path}`;
+}

--- a/src/utils/apiUrl.js
+++ b/src/utils/apiUrl.js
@@ -24,7 +24,12 @@ const ORIGIN = process.env.NEXT_PUBLIC_EXPRESS_SERVER;
 export function apiGetUrl(path) {
   const head = String(path).split(/[/?&]/)[0];
   if (typeof window !== "undefined" && PROXIED_ENDPOINTS.has(head)) {
-    return `/api/ss/${path}`;
+    // next.config has trailingSlash:true, which 308-redirects un-slashed URLs.
+    // Emit the canonical trailing-slash URL (slash placed before any query
+    // string) so the client hits the cached endpoint directly with no hop.
+    const [p, query] = String(path).split("?");
+    const slashed = p.endsWith("/") ? p : `${p}/`;
+    return `/api/ss/${slashed}${query ? `?${query}` : ""}`;
   }
   return `${ORIGIN}${path}`;
 }


### PR DESCRIPTION
## Summary

The homepage's app-load fetches (fixtures, leagues, form, tables, results) currently hit the Express origin directly on every visit, which is the main source of perceived slowness. This adds a same-origin **Vercel proxy** in front of the globally-cacheable GET endpoints so repeat/global traffic is served from the **CDN edge**, and the origin is only woken on revalidation.

- **`pages/api/ss/[...path].js`** — read-through proxy. GET-only, allowlisted endpoints, with per-endpoint `s-maxage` + 24h `stale-while-revalidate`:
  - `matches` 120s · `results` 300s · `tables` 600s · `leagues`/`form`/`formTeam`/`leagueFixtures`/`scheduledEvents` 300s · `league-averages` 600s
  - Origin errors are returned `no-store` so a transient blip isn't pinned at the edge.
- **`src/utils/apiUrl.js`** — `apiGetUrl()` routes allowlisted endpoints through `/api/ss/*` on the client; falls back to the origin server-side.
- Wires the allowlisted **GET reads** in `getFixtures.js`, `getForm.js`, and the `league-averages` read in `getScorePredictions.js` through `apiGetUrl`.

**Deliberately not proxied/cached:** `predictedScores2` and `tipsNEW` (treated as user-specific) and all **writes** (`leagues` POST, `results` POST/DELETE) stay direct to the origin.

## No Vercel config needed
Reuses the existing `NEXT_PUBLIC_EXPRESS_SERVER` env var; API routes deploy as serverless functions automatically; the CDN honours the cache headers.

## Test plan
- [x] `npm run build` succeeds; `/api/ss/[...path]` builds as a serverless function, all pages stay static
- [ ] On the Vercel preview: load homepage, confirm fixtures/leagues/form render correctly
- [ ] `curl -sI https://<preview>/api/ss/leagues/<date>` twice → second shows `x-vercel-cache: HIT`
- [ ] Confirm a date change / future date still loads (cache keys per URL)
- [ ] Confirm login + predictions still work (uncached user-specific endpoints unaffected)

Made with [Cursor](https://cursor.com)